### PR TITLE
fix: use glob-compatible pattern for semver tag filter

### DIFF
--- a/.github/workflows/update-floating-tag.yml
+++ b/.github/workflows/update-floating-tag.yml
@@ -3,7 +3,7 @@ name: update-floating-tag
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- GitHub Actions のタグフィルターは glob パターンのため `+` は量指定子として機能しない
- `v[0-9]+.[0-9]+.[0-9]+` → `v[0-9]*.[0-9]*.[0-9]*` に修正
- これにより `v1.0.0` などの semver タグで `update-floating-tag` が正しく起動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)