### PR TITLE
fix: skip labeling in release-please to avoid PR node resolution error

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           release-type: simple
           token: ${{ secrets.GITHUB_TOKEN }}
+          skip-labeling: true


### PR DESCRIPTION
## Summary

- release-please が PR 作成直後にラベルを付けようとして `Could not resolve to a node with the global id` エラーが発生
- `skip-labeling: true` を追加して回避

## 参考

- release-please 側の既知の問題で、ラベル付けを無効にしても PR/リリース管理の機能自体は正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)