### PR TITLE
ci: set bootstrap-sha to prevent catch-up releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "bootstrap-sha": "238ffcfb16b2368e8f37943e7c92c5da2cdaf6de",
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
   "changelog-sections": [


### PR DESCRIPTION
## Summary

- `bootstrap-sha` を現在の main HEAD に設定し、release-please が過去の古いコミットを拾わないようにする
- あわせて v1.1.0 の GitHub Release / git tag を手動作成済み
- PR #16 (release 1.2.0) はクローズ済み

## 別途必要な対応

GitHub repo Settings → General → Pull Requests:
- **"Allow squash merging"** を有効化
- release PR は必ず **Squash and merge** でマージする

squash merge にしないと、release PR マージ後に release-please が SHA を見つけられず、タグが作られないループが再発します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)