### PR TITLE
fix: document Amazon Linux 2023 support in README behavior section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Install prebuilt ImageMagick binaries from [jksy/imagemagick-build releases](htt
 
 ## Behavior
 
-- Resolves runner OS/arch (`ubuntu-22.04` / `ubuntu-24.04`, `x86_64`)
+- Resolves runner OS/arch:
+  - `ubuntu-22.04` / `ubuntu-24.04` — `x86_64`
+  - `amazonlinux:2023` — `x86_64` / `aarch64`
 - Downloads release asset:
   `imagemagick-${version}-ubuntu24.04-x86_64.tar.gz`
 - Extracts into `install-prefix`


### PR DESCRIPTION
## Summary

- README の Behavior セクションに Amazon Linux 2023 (x86_64 / aarch64) の記載を追加

## リリースフローのテスト目的

このPRは release-please によるリリースフローが正常に動作するかの確認も兼ねています。

### 期待される動作
1. このPRを **Squash and merge** でマージ
2. release-please が自動で release PR (v1.1.1) を作成
3. release PR を **Squash and merge** でマージ
4. `v1.1.1` タグ + GitHub Release が自動作成
5. `v1` フローティングタグが `v1.1.1` に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)