### PR TITLE
ci: remove bootstrap-sha (causes SHA not found on release tag lookup)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "bootstrap-sha": "238ffcfb16b2368e8f37943e7c92c5da2cdaf6de",
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
   "changelog-sections": [


### PR DESCRIPTION
## 問題

`bootstrap-sha` を設定することで release-please のコミット検索範囲が制限され、リリースタグの SHA 検索時にも「SHA not found in recent commits」エラーが発生していた。

結果として release PR マージ後にタグが作成されず、release-please が毎回新しい release PR を作り続けるループが発生。

## 修正

`bootstrap-sha` を削除。GitHub Release が存在する状態では release-please はそれを基準に動作するため、過去コミットの catch-up は発生しない。

## 期待される動作

このPRを Squash and merge → release-please が実行 → v1.1.1 タグ + GitHub Release が作成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)