### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
手動トリガーを可能にする。

また v1.1.0 GitHub Release の `target_commitish` を `"main"` から実際のコミット SHA に修正済み（これが「SHA not found」の真の原因だった）。

このPRをマージすると release-please が動いて v1.1.1 タグが作られるはず。

🤖 Generated with [Claude Code](https://claude.com/claude-code)