### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-floating-tag.yml
+++ b/.github/workflows/update-floating-tag.yml
@@ -13,6 +13,9 @@ on:
         options:
           - v1
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jksy/setup-imagemagick/security/code-scanning/1](https://github.com/jksy/setup-imagemagick/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/update-floating-tag.yml` at the workflow root (top-level), so all jobs inherit it unless overridden.  
For this workflow, the required permission is `contents: write` because it force-updates and pushes a Git tag. This is the narrowest practical scope for this behavior and preserves existing functionality.

**Change location:** directly after `on:` block (before `jobs:`), or near the top-level keys.  
**Needed additions:** a YAML `permissions` mapping:
- `contents: write`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
