### PR TITLE
feat: log bundled library versions from VERSIONS file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -318,3 +318,14 @@ append_env_if_requested "$INSTALL_PREFIX" "$ADD_TO_PATH" "$EXPORT_ENV"
 emit_outputs "$INSTALL_PREFIX" "$MAGICK_PATH"
 
 LD_LIBRARY_PATH="$INSTALL_PREFIX/lib:${LD_LIBRARY_PATH:-}" "$MAGICK_PATH" -version
+
+echo "::group::Bundled library versions"
+VERSIONS_FILE="$INSTALL_PREFIX/VERSIONS"
+if [[ -f "$VERSIONS_FILE" ]]; then
+  while IFS='=' read -r lib_name lib_ver; do
+    printf '  %-20s %s\n' "$lib_name" "$lib_ver"
+  done < "$VERSIONS_FILE"
+else
+  echo "::warning::VERSIONS file not found (older release)"
+fi
+echo "::endgroup::"


### PR DESCRIPTION
## Summary

- `magick -version` 実行後、`$INSTALL_PREFIX/VERSIONS` を読み込みバンドルライブラリのバージョンを `::group::` ブロックで出力する
- `VERSIONS` ファイルが存在しない旧リリースの場合は `::warning::` を出して終了しない（後方互換あり）

## Test plan

- [x] `VERSIONS` ファイルが含まれる最新リリースでインストールし、Actionsログに `Bundled library versions` グループが表示されること
- [ ] 旧リリース（`VERSIONS` なし）では `::warning::` のみ出力され、インストールは正常完了すること

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)